### PR TITLE
removed unnecessary arduino espressif package target

### DIFF
--- a/example/Factory/platformio.ini
+++ b/example/Factory/platformio.ini
@@ -17,9 +17,6 @@ platform = espressif32
 board = esp32-s3-devkitc-1
 framework = arduino
 
-platform_packages =
-    framework-arduinoespressif32@https://github.com/espressif/arduino-esp32.git#2.0.5
-
 build_flags = 
     ; -DBOARD_HAS_PSRAM
     -DARDUINO_USB_MODE=1

--- a/example/TFT/platformio.ini
+++ b/example/TFT/platformio.ini
@@ -17,9 +17,6 @@ platform = espressif32
 board = esp32-s3-devkitc-1
 framework = arduino
 
-platform_packages =
-    framework-arduinoespressif32@https://github.com/espressif/arduino-esp32.git#2.0.5
-
 build_flags = 
     ; -DBOARD_HAS_PSRAM
     -DARDUINO_USB_MODE=1
@@ -46,10 +43,8 @@ build_flags =
     -D ST7735_GREENTAB160x80
     -D TFT_RGB_ORDER=TFT_BGR
 
-
 lib_deps =
   bodmer/TFT_eSPI @ ^2.4.75
-
 
 board_build.partitions = huge_app.csv
 ; board_build.arduino.memory_type = qio_opi

--- a/example/USB-MSC/platformio.ini
+++ b/example/USB-MSC/platformio.ini
@@ -17,9 +17,6 @@ platform = espressif32
 board = esp32-s3-devkitc-1
 framework = arduino
 
-platform_packages =
-    framework-arduinoespressif32@https://github.com/espressif/arduino-esp32.git#2.0.5
-
 build_flags = 
     ; -DBOARD_HAS_PSRAM
     -DARDUINO_USB_MODE=1


### PR DESCRIPTION
## Summary
With the last version of PlatformIO we have the next error in the PlatformIO examples:
```cpp
UnknownPackageError: Could not find the package with 'espressif/toolchain-riscv32-esp @ 8.4.0+2021r2-patch3' requirements for your system 'linux_x86_64
``` 
This PR fix this issue.